### PR TITLE
Remove PR matrix tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,19 +18,16 @@ jobs:
         uses: pre-commit/action@v3.0.0
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
     needs: pre-commit
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.9'
     - name: Install pypa/setuptools
       run: |
         python -m pip install build


### PR DESCRIPTION
There's not much point to testing a matrix of Python versions, so this PR updates the tests to run on the minimum supported Python version of 3.9 instead.
