### PR TITLE
Only map video, audio, & subtitle during default convert

### DIFF
--- a/media_management_scripts/convert.py
+++ b/media_management_scripts/convert.py
@@ -207,7 +207,12 @@ def convert_with_config(
         args.extend(["-c:s", "copy"])
 
     if not mappings:
-        args.extend(["-map", "0"])
+        if metadata.video_streams:
+            args.extend(["-map", "0:v"])
+        if metadata.audio_streams:
+            args.extend(["-map", "0:a"])
+        if metadata.subtitle_streams:
+            args.extend(["-map", "0:s"])
     else:
         for m in mappings:
             if type(m) == int:


### PR DESCRIPTION
When performing a regular convert, instead of mapping _all_ streams, only map the video, audio, and subtitles streams.

Some videos include extra "other" streams which often are not easily handled. More than likely, the user doesn't care about these streams, so it's okay to drop them.