### PR TITLE
Allow for encoding UDH/2160p

### DIFF
--- a/media_management_scripts/convert.py
+++ b/media_management_scripts/convert.py
@@ -58,8 +58,10 @@ def auto_bitrate_from_config(resolution, convert_config):
         return convert_config.auto_bitrate_720
     elif resolution == Resolution.HIGH_DEF:
         return convert_config.auto_bitrate_1080
+    elif resolution == Resolution.ULTRA_HIGH_DEF:
+        return convert_config.auto_bitrate_2160
     else:
-        raise Exception("Not auto bitrate for {}".format(resolution))
+        raise Exception("No auto bitrate for {}".format(resolution))
 
 
 def convert_with_config(
@@ -99,23 +101,6 @@ def convert_with_config(
             "Metadata provided without interlace report, but convert requires deinterlace checks"
         )
 
-    if (
-        metadata.resolution
-        not in (
-            Resolution.LOW_DEF,
-            Resolution.STANDARD_DEF,
-            Resolution.MEDIUM_DEF,
-            Resolution.HIGH_DEF,
-        )
-        and not config.scale
-    ):
-        print(
-            "{}: Resolution not supported for conversion: {}".format(
-                input, metadata.resolution
-            )
-        )
-        # TODO Handle converting 4k content in H.265/HVEC
-        return -2
     if use_nice and nice_exe:
         args = [nice_exe, ffmpeg()]
     else:
@@ -166,6 +151,8 @@ def convert_with_config(
         # -x264-params vbv-maxrate=1666:vbv-bufsize=3332:crf-max=22:qpmax=34
         if config.bitrate == "auto":
             bitrate = auto_bitrate_from_config(metadata.resolution, config)
+        else:
+            bitrate = int(config.bitrate)
         params = "vbv-maxrate={}:vbv-bufsize={}:crf-max=25:qpmax=34".format(
             str(bitrate), str(bitrate * 2)
         )

--- a/media_management_scripts/support/encoding.py
+++ b/media_management_scripts/support/encoding.py
@@ -10,7 +10,7 @@ class Resolution(Enum):
     STANDARD_DEF = (720, 480, 1600, "auto_bitrate_480")
     MEDIUM_DEF = (1280, 720, 4500, "auto_bitrate_720")
     HIGH_DEF = (1920, 1080, 8000, "auto_bitrate_1080")
-    ULTRA_HIGH_DEF = (3840, 2160, -1, None)
+    ULTRA_HIGH_DEF = (3840, 2160, 14_500, None)
 
     @property
     def width(self):

--- a/media_management_scripts/support/metadata.py
+++ b/media_management_scripts/support/metadata.py
@@ -76,7 +76,13 @@ class Metadata:
 
         if self.video_streams:
             max_height = max(self.video_streams, key=lambda s: s.height or 0).height
-            self.resolution = resolution_name(max_height)
+            max_width = max(self.video_streams, key=lambda s: s.width or 0).width
+            if max_height and max_width:
+                self.resolution = resolution_name(min(max_height, max_width))
+            elif max_height:
+                self.resolution = resolution_name(max_height)
+            elif max_width:
+                self.resolution = resolution_name(max_width)
         else:
             self.resolution = None
 

--- a/media_management_scripts/utils.py
+++ b/media_management_scripts/utils.py
@@ -102,6 +102,7 @@ class ConvertConfig(NamedTuple):
     auto_bitrate_480: int = Resolution.STANDARD_DEF.auto_bitrate
     auto_bitrate_720: int = Resolution.MEDIUM_DEF.auto_bitrate
     auto_bitrate_1080: int = Resolution.HIGH_DEF.auto_bitrate
+    auto_bitrate_2160: int = Resolution.ULTRA_HIGH_DEF.auto_bitrate
     scale: Optional[int] = None
     video_codec: str = VideoCodec.H264.ffmpeg_encoder_name
     audio_codec: str = AudioCodec.AAC.ffmpeg_codec_name


### PR DESCRIPTION
1. Adds an auto bitrate for UHD (2160) resolution.
2. Allows for encoding in UHD.
3. Use the minimum of width or height for a video for the resolution to allow for vertical filming