### PR TITLE
Add support for apple hardware acceleration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It also simplifies some common tasks such as converting files by wrapping comple
 
 For example, to convert a file to H.265/HEVC with GPU acceleration and AAC audio, plus scale it down to 480p, you would normally have to run a command like:
 ```sh
-ffmpeg -hwaccel cuda -hwaccel_output_format cuda -i test.mp4 -vf scale=-1:480 -c:v hevc_nvenc -preset fast -c:a aac -c:s copy -map 0 out.mp4
+ffmpeg -hwaccel cuda -hwaccel_output_format cuda -i test.mp4 -vf scale=-1:480 -c:v hevc_nvenc -preset fast -c:a aac -c:s copy -map 0:v -map 0:a -map 0:s out.mp4
 ```
 Using this toolkit, it would be this instead:
 ```sh
@@ -118,13 +118,30 @@ The source file is left intact.
     - `manage-media convert --vc copy --ac copy --start 3m45s --end 10m00s <input> <output>`
 
 ### Hardware Acceleration
-If your `ffmpeg` [supports it](https://trac.ffmpeg.org/wiki/HWAccelIntro#CUDANVENCNVDEC), you can use NVIDIA GPU hardware acceleration to speed up the conversion. You can see the supported codecs for decoding & encoding for each GPU [here](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
+
+Your `ffmpeg` must support the hardware acceleration you want to use. You can check this with `ffmpeg -hwaccels`. If you see `cuda` or `videotoolbox`, then you can use the hardware acceleration below.
+
+Using this can speed up the conversion process significantly!
+
+#### NVIDIA (`cuda`)
+
+If your `ffmpeg` [supports it](https://trac.ffmpeg.org/wiki/HWAccelIntro#CUDANVENCNVDEC) and you have an NVIDIA GPU, you can use hardware acceleration to speed up the conversion. You can see the supported codecs for decoding & encoding for each GPU [here](https://developer.nvidia.com/video-encode-and-decode-gpu-support-matrix-new).
 
 To use this, just add `--hardware-nvidia` or `--hw-nv` to the `manage-media convert` command.
 
 ```
 manage-media convert --hw-nv --video-codec hevc --audio-codec ac3 <input> <output>
 ```
+
+#### Apple (`videotoolbox`)
+
+If your `ffmpeg` [supports it](https://trac.ffmpeg.org/wiki/HWAccelIntro#VideoToolbox) and you are using a Mac with Apple Silicon, you can use hardware acceleration for encoding by adding `--hardware-apple` or `--hw-apple` to the `manage-media convert` command.
+
+```
+manage-media convert --hw-apple --video-codec h264 --audio-codec copy <input> <output>
+```
+
+Note: this might also work onn Intel Macs, but it is untested.
 
 ## metadata
 

--- a/media_management_scripts/commands/common.py
+++ b/media_management_scripts/commands/common.py
@@ -165,6 +165,16 @@ convert_parent_parser.add_argument(
     help="Use NVIDIA hardware acceleration for decoding and encoding",
 )
 
+convert_parent_parser.add_argument(
+    "--hardware-apple",
+    "--hw-apple",
+    dest="hardware_apple",
+    default=False,
+    action="store_const",
+    const=True,
+    help="Use Apple Silicon hardware acceleration for encoding",
+)
+
 __all__ = [
     # Parsers
     "parent_parser",

--- a/media_management_scripts/support/encoding.py
+++ b/media_management_scripts/support/encoding.py
@@ -69,10 +69,10 @@ def resolution_name(height):
 
 
 class VideoCodec(Enum):
-    H264 = ("libx264", ["h264"], "h264_nvenc")
-    H265 = ("libx265", ["hevc", "h265"], "hevc_nvenc")
-    MPEG2 = ("mpeg2video", ["mpeg2video", "mpeg2"], None)
-    COPY = ("copy", ["copy"], "copy")
+    H264 = ("libx264", ["h264"], "h264_nvenc", "h264_videotoolbox")
+    H265 = ("libx265", ["hevc", "h265"], "hevc_nvenc", "hevc_videotoolbox")
+    MPEG2 = ("mpeg2video", ["mpeg2video", "mpeg2"], None, None)
+    COPY = ("copy", ["copy"], "copy", "copy")
 
     @property
     def ffmpeg_encoder_name(self):
@@ -89,6 +89,10 @@ class VideoCodec(Enum):
     @property
     def nvidia_codec_name(self):
         return self.value[2]
+
+    @property
+    def apple_codec_name(self):
+        return self.value[3]
 
     @staticmethod
     def from_code_name(name):

--- a/media_management_scripts/utils.py
+++ b/media_management_scripts/utils.py
@@ -107,6 +107,11 @@ class ConvertConfig(NamedTuple):
     video_codec: str = VideoCodec.H264.ffmpeg_encoder_name
     audio_codec: str = AudioCodec.AAC.ffmpeg_codec_name
     hardware_nvidia: bool = False
+    hardware_apple: bool = False
+
+    @property
+    def hardware_accelerated(self):
+        return self.hardware_nvidia or self.hardware_apple
 
 
 def convert_config_from_config_section(


### PR DESCRIPTION
Adds support for using Video Toolbox encoding on MacOS if the `ffmpeg` supports it.

Add `--hardware-apple` or `--hw-apple` to `manage-media convert` to enable this.